### PR TITLE
Improve performance on numpy backend 

### DIFF
--- a/qiskit_ode/dispatch/array.py
+++ b/qiskit_ode/dispatch/array.py
@@ -75,13 +75,9 @@ class Array(NDArrayOperatorsMixin):
         # set _data and _backend directly
         if (
             isinstance(data, numpy.ndarray)
-            and (backend == "numpy" or (not backend and Dispatch.DEFAULT_BACKEND == "numpy"))
+            and _is_numpy_backend(backend)
             and (not dtype or dtype == data.dtype)
-            and (
-                not order
-                or (order == "C" and data.flags["C_CONTIGUOUS"])
-                or (order == "F" and data.flags["F_CONTIGUOUS"])
-            )
+            and _is_equivalent_numpy_array(data, dtype, order)
         ):
             self.__dict__["_data"] = data
             self.__dict__["_backend"] = "numpy"
@@ -294,3 +290,15 @@ class Array(NDArrayOperatorsMixin):
             return NotImplemented
         result = dispatch_func(*args, **kwargs)
         return self._wrap(result, backend=self.backend)
+
+
+def _is_numpy_backend(backend: Optional[str] = None):
+    return backend == "numpy" or (not backend and Dispatch.DEFAULT_BACKEND == "numpy")
+
+
+def _is_equivalent_numpy_array(data: any, dtype: Optional[any] = None, order: Optional[str] = None):
+    return (not dtype or dtype == data.dtype) and (
+        not order
+        or (order == "C" and data.flags["C_CONTIGUOUS"])
+        or (order == "F" and data.flags["F_CONTIGUOUS"])
+    )

--- a/qiskit_ode/dispatch/array.py
+++ b/qiskit_ode/dispatch/array.py
@@ -76,7 +76,6 @@ class Array(NDArrayOperatorsMixin):
         if (
             isinstance(data, numpy.ndarray)
             and _is_numpy_backend(backend)
-            and (not dtype or dtype == data.dtype)
             and _is_equivalent_numpy_array(data, dtype, order)
         ):
             self.__dict__["_data"] = data

--- a/qiskit_ode/dispatch/array.py
+++ b/qiskit_ode/dispatch/array.py
@@ -73,13 +73,18 @@ class Array(NDArrayOperatorsMixin):
 
         # Check if we can override setattr and
         # set _data and _backend directly
-        if isinstance(data, numpy.ndarray) \
-                and (backend == "numpy" or (not backend and Dispatch.DEFAULT_BACKEND == "numpy")) \
-                and (not dtype or dtype == data.dtype) \
-                and (not order or (order == "C" and data.flags["C_CONTIGUOUS"]) \
-                or (order == "F" and data.flags["F_CONTIGUOUS"])):
-            self.__dict__['_data'] = data
-            self.__dict__['_backend'] = "numpy"
+        if (
+            isinstance(data, numpy.ndarray)
+            and (backend == "numpy" or (not backend and Dispatch.DEFAULT_BACKEND == "numpy"))
+            and (not dtype or dtype == data.dtype)
+            and (
+                not order
+                or (order == "C" and data.flags["C_CONTIGUOUS"])
+                or (order == "F" and data.flags["F_CONTIGUOUS"])
+            )
+        ):
+            self.__dict__["_data"] = data
+            self.__dict__["_backend"] = "numpy"
             return
 
         if hasattr(data, "__qiskit_array__"):

--- a/qiskit_ode/dispatch/array.py
+++ b/qiskit_ode/dispatch/array.py
@@ -70,6 +70,18 @@ class Array(NDArrayOperatorsMixin):
         Raises:
             ValueError: if input cannot be converted to an Array.
         """
+
+        # Check if we can override setattr and
+        # set _data and _backend directly
+        if isinstance(data, numpy.ndarray) \
+                and (backend == "numpy" or (not backend and Dispatch.DEFAULT_BACKEND == "numpy")) \
+                and (not dtype or dtype == data.dtype) \
+                and (not order or (order == "C" and data.flags["C_CONTIGUOUS"]) \
+                or (order == "F" and data.flags["F_CONTIGUOUS"])):
+            self.__dict__['_data'] = data
+            self.__dict__['_backend'] = "numpy"
+            return
+
         if hasattr(data, "__qiskit_array__"):
             array = data.__qiskit_array__(dtype=dtype, backend=backend)
             if not isinstance(array, Array):

--- a/qiskit_ode/signals/signals.py
+++ b/qiskit_ode/signals/signals.py
@@ -157,9 +157,9 @@ class Signal(BaseSignal):
         self._carrier_freq = Array(carrier_freq)
         self._phase = Array(phase)
 
-    def envelope_value(self, t: float = 0.0) -> Array:
+    def envelope_value(self, t: float = 0.0) -> complex:
         """Evaluates the envelope at time t."""
-        return Array(self.envelope(t))
+        return self.envelope(t)
 
     def value(self, t: float = 0.0) -> Array:
         """Return the value of the signal at time t."""
@@ -454,8 +454,7 @@ class VectorSignal:
 
         # define the envelope as iteratively evaluating the envelopes
         def env_func(t):
-            return Array([Array(sig.envelope_value(t)).data for sig in signal_list])
-
+            return Array([sig.envelope_value(t) for sig in signal_list])
         # construct carrier frequency and phase list
         # if signal doesn't have a carrier, set to 0.
         carrier_freqs = Array(

--- a/qiskit_ode/signals/signals.py
+++ b/qiskit_ode/signals/signals.py
@@ -455,6 +455,7 @@ class VectorSignal:
         # define the envelope as iteratively evaluating the envelopes
         def env_func(t):
             return Array([sig.envelope_value(t) for sig in signal_list])
+
         # construct carrier frequency and phase list
         # if signal doesn't have a carrier, set to 0.
         carrier_freqs = Array(


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Improve performance on numpy backend reducing the number of array objects construction and improving performance on array construction for numpy arrays. Construction performance is improved bypassing  `setattr` when we have a numpy array and we don't need to transform it to other data type or order. 

### Details and comments

Some plots showing performance gains when running **Numpy lsoda** section of **Benchmarking-CR_drive** notebook:

![numpy_array_times_comp](https://user-images.githubusercontent.com/59838221/113159417-e144af00-923c-11eb-9f43-641caa026a94.png)
![numpy_array_times](https://user-images.githubusercontent.com/59838221/113159455-e73a9000-923c-11eb-9e06-5506437cc4da.png)


