### PR TITLE
Fixing bug in DiscreteSignalSum iterator construction

### DIFF
--- a/qiskit_ode/signals/signals.py
+++ b/qiskit_ode/signals/signals.py
@@ -494,6 +494,10 @@ class SignalCollection:
         else:
             return sublist
 
+    def __iter__(self):
+        """Return iterator over component list."""
+        return self.components.__iter__()
+
     def conjugate(self) -> "SignalCollection":
         """Return the conjugation of this collection."""
         return self.__class__([sig.conjugate() for sig in self.components])
@@ -747,6 +751,9 @@ class DiscreteSignalSum(DiscreteSignal, SignalSum):
     def __getitem__(self, idx: Union[int, List, np.array, slice]) -> Signal:
         """Enables numpy-style subscripting, as if this class were a 1d array."""
 
+        if type(idx) == int and idx >= len(self):
+            raise IndexError("index out of range for DiscreteSignalSum of length " + str(len(self)))
+
         samples = self.samples[:, idx]
         carrier_freqs = self.carrier_freq[idx]
         phases = self.phase[idx]
@@ -826,7 +833,6 @@ class SignalList(SignalCollection):
         """
 
         drift_array = []
-
         for sig_entry in self.components:
             val = 0.0
 

--- a/test/ode/signals/test_signals.py
+++ b/test/ode/signals/test_signals.py
@@ -819,6 +819,24 @@ class TestSignalCollection(QiskitOdeTestCase):
         t_vals = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]) / 4.0
         self.assertAllClose(sub02(t_vals), self.discrete_sig1(t_vals) + self.discrete_sig3(t_vals))
 
+    def test_SignalSum_iterator(self):
+        """Test iteration of SignalSum."""
+
+        sum_val = 0.0
+        for sig in self.sig_sum:
+            sum_val += sig(3.0)
+
+        self.assertAllClose(sum_val, self.sig_sum(3.0))
+
+    def test_DiscreteSignalSum_iterator(self):
+        """Test iteration of DiscreteSignalSum."""
+
+        sum_val = 0.0
+        for sig in self.discrete_sig_sum:
+            sum_val += sig(3.0)
+
+        self.assertAllClose(sum_val, self.discrete_sig_sum(3.0))
+
 
 class TestSignalJax(TestSignal, TestJaxBase):
     """Jax version of TestSignal."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixing infinite loops when iterating over a `DiscreteSignalSum` object.

### Details and comments

`SignalSum` and `DiscreteSignalSum` implement `__getitem__` so they can be index liked 1d arrays. In python, if a class implements `__getitem__` but not `__iter__`, iteration on the class will proceed by calling `__getitem__` with increasing `int`s until an error is raised. This works fine for `SignalSum`, but `DiscreteSignalSum.__getitem__` was implemented by directly subscripting the arrays it contains, and jax arrays are weird in that when you try to index an array with an `int` greater than the length, it'll just return the last element, so no error ever gets raised, hence infinite loop.

Changes:
- Implemented `__iter__` to `SignalCollection`, the class that `SignalSum` and `DiscreteSignalSum` inherit from. `__iter__` now directly returns the iterator over the list of components in the sum,  so python no longer uses `__getitem__` to construct the iterator.
- Modified `DiscreteSignalSum.__getitem__` to raise an `IndexError` if `idx >= len(self)` (this is not necessary for `SignalCollection` as the default is to directly index the internal component list)
- Added tests for iteration on these classes.